### PR TITLE
Updated CMake files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,9 +4,9 @@
 cmake_minimum_required (VERSION 3.21)
 
 project (Mp2tStrm
-	VERSION 1.0.1
-	DESCRIPTION "MPEG-2 TS file streamer application and library."
-	LANGUAGES C CXX
+  VERSION 1.0.1
+  DESCRIPTION "MPEG-2 TS file streamer application and library."
+  LANGUAGES C CXX
 )
 
 include(GNUInstallDirs)
@@ -14,27 +14,19 @@ include(GNUInstallDirs)
 # Include sub-projects.
 add_subdirectory (Mp2tStrmLib)
 
-add_executable(Mp2tStrmApp)
+add_executable(Mp2tStreamer)
 
-target_sources(Mp2tStrmApp PRIVATE src/main.cpp)
+target_sources(Mp2tStreamer PRIVATE src/main.cpp)
 
-if(WIN32)
-    list(APPEND EXTRA_LIBS Mp2tStrm wsock32 ws2_32)
-else()
-    list(APPEND EXTRA_LIBS Mp2tStrm)
-endif()
+target_link_libraries(Mp2tStreamer PRIVATE Mp2tStrm)
 
-target_link_libraries(Mp2tStrmApp PRIVATE ${EXTRA_LIBS})
-
-install (TARGETS Mp2tStrmApp)
+install(TARGETS Mp2tStreamer)
 
 # Test cases
 enable_testing()
 
-set(args -s ${PROJECT_SOURCE_DIR}/sample/foreman_cif_klv.ts -d 239.3.1.11:50000 -t 255)
-
 add_test(NAME Stream
-	COMMAND Mp2tStrmApp ${args})
+  COMMAND Mp2tStreamer -s ${PROJECT_SOURCE_DIR}/sample/foreman_cif_klv.ts -d 239.3.1.11:50000 -t 255)
 set_tests_properties(Stream
-	PROPERTIES PASS_REGULAR_EXPRESSION "TS Packets Read: 4234\nUDP Packets Sent: 604"
-	)
+  PROPERTIES PASS_REGULAR_EXPRESSION "TS Packets Read: 4234\nUDP Packets Sent: 604"
+)

--- a/Mp2tStrmLib/CMakeLists.txt
+++ b/Mp2tStrmLib/CMakeLists.txt
@@ -3,13 +3,24 @@ cmake_minimum_required (VERSION 3.21)
 project(Mp2tStrm
     VERSION 1.0.1
     DESCRIPTION "MPEG-2 TS Streamer Library"
-    LANGUAGES C CXX)
-	
-include(GNUInstallDirs)
+    LANGUAGES C CXX
+)
 
-# This is the default install directory for config-file package cmake files
-# It is relative to install prefix.
-set(Mp2tStrm_INSTALL_CMAKEDIR cmake CACHE PATH "Installation directory for config-file package cmake files")
+# include the module `ExternalProject`
+include(ExternalProject)
+
+# Add an external project from a downloaded source archive
+ExternalProject_Add(loki-lib
+  URL https://github.com/snaewe/loki-lib/archive/refs/tags/Release_0_1_5.tar.gz
+  URL_HASH MD5=74e60c683f745dc15c6e772927349483
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND ""
+  INSTALL_COMMAND ""
+)
+
+ExternalProject_Get_Property(loki-lib SOURCE_DIR)
+
+set(LOKI_DIR "${SOURCE_DIR}")
 
 # set the postfix "d" for the resulting .so or .dll files when building the
 # library in debug mode
@@ -20,24 +31,44 @@ find_package(h264p 1 CONFIG REQUIRED)
 
 add_library(Mp2tStrm STATIC)
 
-file(GLOB SRC_LIST
-    src/*.cpp)
-
-target_sources(Mp2tStrm PRIVATE ${SRC_LIST})
+target_sources(Mp2tStrm 
+  PRIVATE
+    include/Mp2tStrm/CommandLineParser.h
+    include/Mp2tStrm/Mp2tStreamer.h
+    src/AccessUnit.cpp
+    src/AccessUnit.h
+    src/BoundedBuffer.h
+    src/CommandLineParser.cpp
+    src/FileReader.cpp
+    src/FileReader.h
+    src/H264Prober.cpp
+    src/H264Prober.h
+    src/LockFreeQueue.h
+    src/Mp2tStreamer.cpp
+    src/Mpeg2TsDecoder.cpp
+    src/Mpeg2TsDecoder.h
+    src/Mpeg2TsProber.cpp
+    src/Mpeg2TsProber.h
+    src/PCRClock.cpp
+    src/PCRClock.h
+    src/Pid2TypeMap.cpp
+    src/Pid2TypeMap.h
+    src/RateLimiter.cpp
+    src/RateLimiter.h
+    src/UdpData.cpp
+    src/UdpData.h
+    src/UdpSender.cpp
+    src/UdpSender.h
+)
 
 set_property(TARGET Mp2tStrm PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 add_compile_definitions(QSIZE=100)
 
 # specify the C++ standard
-target_compile_features(
-    Mp2tStrm
-    PUBLIC cxx_std_14
-)
+target_compile_features(Mp2tStrm PUBLIC cxx_std_14)
 
-set(LOKI_DIRECTORY ../../loki-lib/include)
-
-include_directories(${LOKI_DIRECTORY})
+add_dependencies(Mp2tStrm loki-lib)
 
 if (WIN32)
     include_directories(../../)
@@ -47,8 +78,11 @@ else()
 endif()
 
 target_include_directories(Mp2tStrm
-	PRIVATE src/Mp2tStrm
-	PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  PRIVATE 
+    src/Mp2tStrm
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<BUILD_INTERFACE:${LOKI_DIR}/include>
 )
 
 # Comment out install commands for now.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Mp2tStrm
 For users that have MPEG-2 TS files (*.ts)
 who need to restream them over an IP network.
-The MPEG-2 TS File Streamer `Mp2tStrmApp` is a command line tool that
+The MPEG-2 TS File Streamer `Mp2tStreamer` is a command line tool that
 will allow clients to retransmit a MPEG-2 TS stream from a file onto an
 IP network.  Unlike Colasoft Packet Player that retransmit video from
 a Wireshark capture file, this tool will allow users to replay a video
@@ -10,25 +10,26 @@ stream from a MPEG-2 TS file.
 ## How To Build
 This project has an external dependency on:
 
- - [loki library](https://github.com/snaewe/loki-lib.git) clone in the same directory where this project was cloned.
  - [mp2t library](https://github.com/jimcavoy/mp2tp) build and install the library.
  - [h264p library](https://github.com/jimcavoy/h264p) build and install the library.
 
 `Mp2tStrm` is a CMake project.  To configure and build the project use the following commands:
 
- - cmake -S . -B ./build
- - cmake --build ./build
- - cmake --install ./build
+    cmake -S . -B ./build
+
+    cmake --build ./build
+
+    cmake --install ./build
 
 ### To Test
 The project has a test case.  Run the following command:
 
  - ctest --test-dir ./build
 
-The test case duration is about 13 seconds.  
+The test case duration is about 13 seconds.
 
 ## Usage
-Usage: Mp2tStrmApp.exe [-?] [-p] [-s|-] [-d 127.0.0.1:50000] [-t [0..255]] [-i STRING] [-f DOUBLE]
+Usage: Mp2tStreamer.exe [-?] [-p] [-s|-] [-d 127.0.0.1:50000] [-t [0..255]] [-i STRING] [-f DOUBLE]
 
 Options:
 
@@ -52,19 +53,19 @@ Help options:
 
 1. Stream a file
 
-	> Mp2tStrmApp.exe -s C:\Samples\somefile.ts -d 239.3.1.11:50000
-	
+    Mp2tStreamer.exe -s C:\Samples\somefile.ts -d 239.3.1.11:50000
+
 2. Pipe a file into Mp2tStrm application to stream.  Ensure the `-f` parameter is set greater than 0.
 
-	> Mp2tStrmApp.exe -d 239.3.1.11:50000 -f 29.97 < C:\Samples\somefile.ts
+    Mp2tStreamer.exe -d 239.3.1.11:50000 -f 29.97 < C:\Samples\somefile.ts
 
 3. Pipe Motion Imagery stream from another application.  Ensure the `-f` parameter is set greater than 0.
 
-	> SampleApp.exe | Mp2tStrmApp.exe -d239.3.1.11:50000 -f 30
+    SampleApp.exe | Mp2tStreamer.exe -d239.3.1.11:50000 -f 30
 
 SampleApp.exe is an application that streams Motion Imagery data out to 
-console and is piped into Mp2tStrmApp.exe.
+console and is piped into Mp2tStreamer.exe.
 
 4. Probe a file and exit
 
-	> Mp2tStrmApp.exe -s C:\Samples\somefile.ts -p
+    Mp2tStreamer.exe -s C:\Samples\somefile.ts -p


### PR DESCRIPTION
Edited cmake files to follow modern cmake practices such as avoiding custom variables in project commands. Updated README.md.
Change name of root target executable from Mp2tStrmApp to Mp2tStreamer.