### PR TITLE
Improve probing

### DIFF
--- a/Mp2tStrmLib/src/CommandLineParser.cpp
+++ b/Mp2tStrmLib/src/CommandLineParser.cpp
@@ -7,7 +7,7 @@
 
 using namespace std;
 
-const char* usage = "\nUsage: Mp2tStrmApp.exe [-?] [-p] [-s|-] [-d 127.0.0.1:50000] [-t [0..255]] [-i STRING] [-f DOUBLE]";
+const char* usage = "\nUsage: Mp2tStreamer.exe [-?] [-p] [-s|-] [-d 127.0.0.1:50000] [-t [0..255]] [-i STRING] [-f DOUBLE]";
 const char* opts = "  -s\tThe source MPEG-2 TS file path (default: -).\n \
  -d\tThe destination socket address (ip:port) (default: 127.0.0.1:50000).\n \
  -t\tTime to Live. (default: 16)\n \

--- a/Mp2tStrmLib/src/Mp2tStreamer.cpp
+++ b/Mp2tStrmLib/src/Mp2tStreamer.cpp
@@ -226,7 +226,11 @@ int ThetaStream::Mp2tStreamer::metadataFrequency() const
 
 double ThetaStream::Mp2tStreamer::framesPerSecond() const
 {
-	return _pimpl->_prober.h264Prober().framesPerSecond() > 0.0 ? _pimpl->_prober.h264Prober().framesPerSecond() : _pimpl->_arguments.framesPerSecond();
+	// Frame rate pass in as a command line parameter overrides the video frame rate.
+	if (_pimpl->_arguments.framesPerSecond() > 0)
+		return _pimpl->_arguments.framesPerSecond();
+
+	return _pimpl->_prober.framesPerSecond();
 }
 
 int ThetaStream::Mp2tStreamer::width() const

--- a/Mp2tStrmLib/src/Mp2tStreamer.cpp
+++ b/Mp2tStrmLib/src/Mp2tStreamer.cpp
@@ -159,10 +159,9 @@ int ThetaStream::Mp2tStreamer::run()
 #ifdef PERFCNTR
 	perfCounter.stop();
 	perfCounterThread.join();
-#else
+#endif
 	_pimpl->_tsRead = _pimpl->_fileReader->count();
 	_pimpl->_udpSent = _pimpl->_sender->count();
-#endif
 	return 0;
 }
 

--- a/Mp2tStrmLib/src/Mpeg2TsProber.h
+++ b/Mp2tStrmLib/src/Mpeg2TsProber.h
@@ -18,6 +18,7 @@ public:
 	double averageBitrate() const;
 	std::string metadataCarriage() const;
 	int metadataFrequency() const;
+	double framesPerSecond() const;
 
 	const H264Prober& h264Prober() const;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -34,7 +34,7 @@ BOOL CtrlHandler(DWORD fdwCtrlType)
 
 void banner()
 {
-	std::cerr << "Mp2tStrmApp: MPEG-2 TS Streamer Application v1.0.0" << std::endl;
+	std::cerr << "Mp2tStreamer: MPEG-2 TS Streamer Application v1.0.0" << std::endl;
 	std::cerr << "Copyright (c) 2024 ThetaStream Consulting, jimcavoy@thetastream.com" << std::endl;
 }
 
@@ -48,7 +48,7 @@ int main(int argc, char *argv[])
 		banner();
 
 		ThetaStream::CommandLineParser cmdline;
-		cmdline.parse(argc, argv, "Mp2tStrmApp.exe");
+		cmdline.parse(argc, argv, "Mp2tStreamer.exe");
 		int ret = 0;
 
 		std::cerr << std::endl << "Enter Ctrl-C to exit" << std::endl << std::endl;


### PR DESCRIPTION
Sometimes, the h.264 video stream may have missing information to determine its frame rate or the video is encoded using different codec other than h.264.  Changes in this PR use other means to determine the video framerate without probing the video stream.