### PR TITLE
Rate Limiter Changes

### DIFF
--- a/Mp2tStrmLib/src/Mpeg2TsDecoder.cpp
+++ b/Mp2tStrmLib/src/Mpeg2TsDecoder.cpp
@@ -109,9 +109,12 @@ void Mpeg2TsDecoder::onPacket(lcss::TransportPacket& pckt)
 					if (_currentAU.timestamp() == 0)
 					{
 						UINT16 pts_dts_flag = (pes.flags2() & PTS_DTS_MASK);
-						UINT64 ts = pts_dts_flag == 0xC0 ? pes.dts() : pes.pts();
-						assert(ts != 0);
-						_currentAU.setTimestamp(ts);
+						if (pts_dts_flag > 0x00)
+						{
+							UINT64 ts = pts_dts_flag == 0xC0 ? pes.dts() : pes.pts();
+							assert(ts != 0);
+							_currentAU.setTimestamp(ts);
+						}
 					}
 					break;
 				}


### PR DESCRIPTION
- Improve frame count when probing non-H.264 video.  Use the dts and pts times.
- When setting an access unit's timestamp, ensure the PES packet has a DTS or PTS value.
- When the access unit is outside a send window, sleep for one millisecond.