### PR TITLE
Bug Fixes

### DIFF
--- a/Mp2tStrmLib/src/Mp2tStreamer.cpp
+++ b/Mp2tStrmLib/src/Mp2tStreamer.cpp
@@ -155,6 +155,8 @@ int ThetaStream::Mp2tStreamer::run()
 
     _pimpl->_tsRead = _pimpl->_fileReader->count();
     _pimpl->_udpSent = _pimpl->_sender->count();
+
+    _pimpl->_state = ThetaStream::Mp2tStreamer::STATE::STOPPED;
     return 0;
 }
 

--- a/Mp2tStrmLib/src/RateLimiter.cpp
+++ b/Mp2tStrmLib/src/RateLimiter.cpp
@@ -43,6 +43,7 @@ void RateLimiter::operator() ()
                 {
                     _startTime = std::chrono::steady_clock::now();
                     _startPts = au.timestamp();
+                    _firstPts = _startPts;
                     add = true;
                 }
                 else if (_startTime == zero && au.timestamp() != 0 && _startPosition > 0)
@@ -52,6 +53,10 @@ void RateLimiter::operator() ()
                         _startTime = std::chrono::steady_clock::now();
                         _startPts = au.timestamp();
                         add = true;
+                    }
+                    else if (_firstPts == 0)
+                    {
+                        _firstPts = au.timestamp();
                     }
                 }
 
@@ -142,7 +147,7 @@ void RateLimiter::poll()
 #ifdef DEBUG
                 std::cout << runTime << ", " << clockTime << ", " << time_span.count() << std::endl;
 #endif
-                _position = runTime;
+                _position = au.timestamp() - _firstPts;
                 _framecount++;
             }
             _outQueue.Put(std::move(au));

--- a/Mp2tStrmLib/src/RateLimiter.h
+++ b/Mp2tStrmLib/src/RateLimiter.h
@@ -43,6 +43,7 @@ private:
     double _framePerSeconds{};
     std::chrono::steady_clock::time_point _startTime{};
     uint64_t _startPts{};
+    uint64_t _firstPts{};
     std::queue<AccessUnit> _queue;
     long _window;
     uint64_t _framecount{};


### PR DESCRIPTION
Before the run function returns, set the state to STOPPED. Capture the first PTS so position is set correctly.