### PR TITLE
Determining Start Time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,5 +52,5 @@ add_test(NAME StartAt10sec
   COMMAND Mp2tStreamer ${PROJECT_SOURCE_DIR}/sample/svt_testset_420_720p50_klved.ts --destinationUrl=udp://239.3.1.11:50000 --startPosition=10)
 set_tests_properties(StartAt10sec
   PROPERTIES PASS_REGULAR_EXPRESSION "TS Packets Read: 268899
-UDP Packets Sent: 32181"
+UDP Packets Sent: 31759"
 )

--- a/Mp2tStrmLib/src/RateLimiter.cpp
+++ b/Mp2tStrmLib/src/RateLimiter.cpp
@@ -48,15 +48,17 @@ void RateLimiter::operator() ()
                 }
                 else if (_startTime == zero && au.timestamp() != 0 && _startPosition > 0)
                 {
-                    if (_startPosition < au.timestamp())
+                    if (_firstPts == 0)
+                    {
+                        _firstPts = au.timestamp();
+                    }
+
+                    uint64_t timespan = au.timestamp() - _firstPts;
+                    if (_startPosition < timespan)
                     {
                         _startTime = std::chrono::steady_clock::now();
                         _startPts = au.timestamp();
                         add = true;
-                    }
-                    else if (_firstPts == 0)
-                    {
-                        _firstPts = au.timestamp();
                     }
                 }
 


### PR DESCRIPTION
Changed how the RateLimiter determine the start time.  Most video do not start at time 0. Updated test case because of this change.