### PR TITLE
Rethrow Exception Issue

### DIFF
--- a/Mp2tStrmLib/src/Mp2tStreamer.cpp
+++ b/Mp2tStrmLib/src/Mp2tStreamer.cpp
@@ -132,7 +132,7 @@ void ThetaStream::Mp2tStreamer::probe()
         _pimpl->ProbeFile();
         _pimpl->_state = ThetaStream::Mp2tStreamer::STATE::STOPPED;
     }
-    catch (const std::exception& ex)
+    catch (const std::runtime_error& ex)
     {
         _pimpl->_state = ThetaStream::Mp2tStreamer::STATE::STOPPED;
         throw ex;


### PR DESCRIPTION
On Linux with gcc, it seems that rethrowing an std::exception the derived type is not preserved and reverts back to the parent class.  Modified the probe funtion to catch the derived type and rethrow it instead of the parent type.