### PR TITLE
Improve Exception Message

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,9 @@ add_subdirectory (Mp2tStrmLib)
 
 add_executable(Mp2tStreamer)
 
+# specify the C++ standard
+target_compile_features(Mp2tStrm PUBLIC cxx_std_17)
+
 target_sources(Mp2tStreamer PRIVATE src/main.cpp)
 
 target_link_libraries(Mp2tStreamer PRIVATE Mp2tStrm)
@@ -54,4 +57,4 @@ UDP Packets Sent: 31759")
 add_test(NAME WrongFormat
   COMMAND Mp2tStreamer ${PROJECT_SOURCE_DIR}/sample/foreman_cif.mp4 --destinationUrl=udp://239.3.1.11:50000)
 set_tests_properties(WrongFormat
-  PROPERTIES PASS_REGULAR_EXPRESSION "ERROR: Wrong format.")
+  PROPERTIES PASS_REGULAR_EXPRESSION "ERROR:")

--- a/Mp2tStrmLib/CMakeLists.txt
+++ b/Mp2tStrmLib/CMakeLists.txt
@@ -65,10 +65,9 @@ set_property(TARGET Mp2tStrm PROPERTY POSITION_INDEPENDENT_CODE ON)
 add_compile_definitions(QSIZE=100)
 
 # specify the C++ standard
-target_compile_features(Mp2tStrm PUBLIC cxx_std_14)
+target_compile_features(Mp2tStrm PUBLIC cxx_std_17)
 
 if (WIN32)
-    include_directories(../../)
     target_link_libraries(Mp2tStrm PRIVATE lcss::mp2tp thetastream::h264p Boost::url Boost::program_options wsock32 ws2_32)
 else()
     target_link_libraries(Mp2tStrm PRIVATE lcss::mp2tp thetastream::h264p Boost::url Boost::program_options pthread)

--- a/Mp2tStrmLib/src/Mp2tStreamer.cpp
+++ b/Mp2tStrmLib/src/Mp2tStreamer.cpp
@@ -10,10 +10,13 @@
 #include <io.h>
 #endif
 #include <fcntl.h>
+#include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <string.h>
 #include <thread>
+
+namespace fs = std::filesystem;
 
 namespace ThetaStream
 {
@@ -86,8 +89,9 @@ namespace ThetaStream
                 bool result = _prober.parse(buffer.data(), (UINT32)len);
                 if (!result)
                 {
+                    fs::path srcPath(_arguments.sourceFile());
                     char szErr[512]{};
-                    sprintf(szErr, "Wrong format. %s is not an MPEG-2 TS file.", _arguments.sourceFile());
+                    sprintf(szErr, "Unsupported multimedia container format. The file, %s, is not an MPEG-2 TS file.", srcPath.filename().string().c_str());
                     std::runtime_error exp(szErr);
                     throw exp;
                 }


### PR DESCRIPTION
Improve exception message thrown from probe function. Use C++ std 17 so we can use filesystem header file.