### PR TITLE
28 display units

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 cmake_minimum_required (VERSION 3.21)
 
 project (Mp2tStrm
-  VERSION 1.4.1
+  VERSION 1.4.2
   DESCRIPTION "MPEG-2 TS file streamer application and library."
   LANGUAGES C CXX
 )
@@ -41,12 +41,12 @@ set_tests_properties(NumTsPacketsStream
 add_test(NAME Probe
   COMMAND Mp2tStreamer ${PROJECT_SOURCE_DIR}/sample/foreman_cif_klv.ts --probe)
 set_tests_properties(Probe
-  PROPERTIES PASS_REGULAR_EXPRESSION "Duration: 11.96
-Average Bitrate: 532.436
+  PROPERTIES PASS_REGULAR_EXPRESSION "11.96 seconds
+Average Bitrate: 532.436 kilobits/second
 Metadata Carriage: Synchronous
-Metadata Frequency: 25
-Frame/Seconds: 25
-Resolution: 352x288")
+Metadata Frequency: 25 Hertz
+Framerate: 25 frames/second
+Resolution: 352x288 pixels")
 
 add_test(NAME StartAt10sec
   COMMAND Mp2tStreamer ${PROJECT_SOURCE_DIR}/sample/svt_testset_420_720p50_klved.ts --destinationUrl=udp://239.3.1.11:50000 --startPosition=10)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ set_tests_properties(NumTsPacketsStream
 add_test(NAME Probe
   COMMAND Mp2tStreamer ${PROJECT_SOURCE_DIR}/sample/foreman_cif_klv.ts --probe)
 set_tests_properties(Probe
-  PROPERTIES PASS_REGULAR_EXPRESSION "11.96 seconds
+  PROPERTIES PASS_REGULAR_EXPRESSION "Duration: 11.96 seconds
 Average Bitrate: 532.436 kilobits/second
 Metadata Carriage: Synchronous
 Metadata Frequency: 25 Hertz

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -140,12 +140,12 @@ int main(int argc, char* argv[])
             std::cerr << "Probing input MPEG-2 TS stream..." << std::endl << std::endl;
             streamer.probe();
 
-            std::cout << "Duration: " << streamer.duration() << std::endl;
-            std::cout << "Average Bitrate: " << streamer.averageBitrate() << std::endl;
+            std::cout << "Duration: " << streamer.duration() << " seconds" << std::endl;
+            std::cout << "Average Bitrate: " << streamer.averageBitrate() << " kilobits/second" << std::endl;
             std::cout << "Metadata Carriage: " << streamer.metadataCarriage() << std::endl;
-            std::cout << "Metadata Frequency: " << streamer.metadataFrequency() << std::endl;
-            std::cout << "Frame/Seconds: " << streamer.framesPerSecond() << std::endl;
-            std::cout << "Resolution: " << streamer.width() << "x" << streamer.height() << std::endl << std::endl;
+            std::cout << "Metadata Frequency: " << streamer.metadataFrequency() << " Hertz" << std::endl;
+            std::cout << "Framerate: " << streamer.framesPerSecond() << " frames/second" << std::endl;
+            std::cout << "Resolution: " << streamer.width() << "x" << streamer.height() << " pixels" << std::endl << std::endl;
         }
 
         if (!cmdline.probe())

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -68,7 +68,7 @@ char getcharAlt()
 
 void banner()
 {
-    std::cerr << "Mp2tStreamer: MPEG-2 TS Streamer Application v1.4.1" << std::endl;
+    std::cerr << "Mp2tStreamer: MPEG-2 TS Streamer Application v1.4.2" << std::endl;
     std::cerr << "Copyright (c) 2025 ThetaStream Consulting, jimcavoy@thetastream.com" << std::endl;
 }
 


### PR DESCRIPTION
Mp2tStreamer displays video metrics after the probe phase.  The application now displays units of measurement for each metrics.