### PR TITLE
Migrate VS 2026

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 cmake_minimum_required (VERSION 3.21)
 
 project (Mp2tStrm
-  VERSION 1.4.2
+  VERSION 1.4.3
   DESCRIPTION "MPEG-2 TS file streamer application and library."
   LANGUAGES C CXX
 )
@@ -17,7 +17,7 @@ add_subdirectory (Mp2tStrmLib)
 add_executable(Mp2tStreamer)
 
 # specify the C++ standard
-target_compile_features(Mp2tStrm PUBLIC cxx_std_17)
+target_compile_features(Mp2tStrm PUBLIC cxx_std_20)
 
 target_sources(Mp2tStreamer PRIVATE src/main.cpp)
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -3,7 +3,7 @@
   "configurePresets": [
     {
       "name": "windows-base",
-      "generator": "Visual Studio 17 2022",
+      "generator": "Visual Studio 18 2026",
       "binaryDir": "${sourceDir}/build",
       "cacheVariables": {
         "CMAKE_C_COMPILER": "cl.exe",

--- a/Mp2tStrmLib/CMakeLists.txt
+++ b/Mp2tStrmLib/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.21)
 
 project(Mp2tStrm
-    VERSION 1.4.1
+    VERSION 1.4.2
     DESCRIPTION "MPEG-2 TS Streamer Library"
     LANGUAGES C CXX
 )
@@ -65,7 +65,7 @@ set_property(TARGET Mp2tStrm PROPERTY POSITION_INDEPENDENT_CODE ON)
 add_compile_definitions(QSIZE=100)
 
 # specify the C++ standard
-target_compile_features(Mp2tStrm PUBLIC cxx_std_17)
+target_compile_features(Mp2tStrm PUBLIC cxx_std_20)
 
 if (WIN32)
     target_link_libraries(Mp2tStrm PRIVATE lcss::mp2tp thetastream::h264p Boost::url Boost::program_options wsock32 ws2_32)

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ The test case duration is about 67 seconds to complete.
 Usage: __Mp2tStreamer__ \<Source MPEG-2 TS File> OPTIONS
 
 ```
+Mp2tStreamer: MPEG-2 TS Streamer Application v1.4.3
+Copyright (c) 2026 ThetaStream Consulting, jimcavoy@thetastream.com
 Allowed options:
   -? [ --help ]                Produce help message.
   --source arg                 Source MPEG-2 TS file path. (default: - )

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -68,8 +68,8 @@ char getcharAlt()
 
 void banner()
 {
-    std::cerr << "Mp2tStreamer: MPEG-2 TS Streamer Application v1.4.2" << std::endl;
-    std::cerr << "Copyright (c) 2025 ThetaStream Consulting, jimcavoy@thetastream.com" << std::endl;
+    std::cerr << "Mp2tStreamer: MPEG-2 TS Streamer Application v1.4.3" << std::endl;
+    std::cerr << "Copyright (c) 2026 ThetaStream Consulting, jimcavoy@thetastream.com" << std::endl;
 }
 
 class InputHandler

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "7f9f0e44db287e8e67c0e888141bfa200ab45121",
+    "baseline": "3895230f38e498525f2560a281223d12066fa74a",
     "repository": "https://github.com/microsoft/vcpkg"
   },
   "registries": [


### PR DESCRIPTION
On Windows, migrate to Visual Studio 2026.
Updated vcpkg baseline.
Bump version number 1.4.3.
Update to C++20.